### PR TITLE
Switch to use 'node-fetch' instead of 'request' to reduce dependency footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ini": "^1.3.4",
     "input": "^1.0.1",
     "jsonwebtoken": "^8.1.0",
-    "request": "^2.83.0",
+    "node-fetch": "^2.3.0",
     "uuid": "^3.1.0",
     "yargs": "^10.0.3"
   },
@@ -39,8 +39,8 @@
     "@types/jest": "^22.1.4",
     "@types/jsonwebtoken": "^7.2.5",
     "@types/node": "^9.4.6",
+    "@types/node-fetch": "^2.1.6",
     "@types/q": "^1.0.7",
-    "@types/request": "^2.47.0",
     "@types/yargs": "^11.0.0",
     "jest": "^22.0.0",
     "lint-staged": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,16 +16,6 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@types/caseless@*":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"
-
-"@types/form-data@*":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
-  dependencies:
-    "@types/node" "*"
-
 "@types/ini@^1.3.29":
   version "1.3.29"
   resolved "https://registry.yarnpkg.com/@types/ini/-/ini-1.3.29.tgz#1325e981e047d40d13ce0359b821475b97741d2f"
@@ -40,6 +30,12 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@^2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.1.6.tgz#4326288b49f352a142f03c63526ebce0f4c50877"
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^9.4.6":
   version "9.4.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
@@ -47,19 +43,6 @@
 "@types/q@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.0.7.tgz#afd4c610f16f6386d320e0738ec38ba7d3431917"
-
-"@types/request@^2.47.0":
-  version "2.47.0"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.47.0.tgz#76a666cee4cb85dcffea6cd4645227926d9e114e"
-  dependencies:
-    "@types/caseless" "*"
-    "@types/form-data" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-
-"@types/tough-cookie@*":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.2.tgz#e0d481d8bb282ad8a8c9e100ceb72c995fb5e709"
 
 "@types/yargs@^11.0.0":
   version "11.0.0"
@@ -2314,6 +2297,10 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Since this package only uses `request` to make a single `POST` request, it seems a bit excessive to use that library, which simulates full browser requests and has a giant cookie-parsing library dependency, to make the Auth token fetch. This change swaps the dependency for one on `node-fetch`, which is significantly smaller.

This change removes the `request` package, adds `node-fetch`, and patches the unit tests to work with the new method call.

This should make it easier to bundle `better-vsts-npm-auth` as a repo script.