### PR TITLE
Fix `config set` not respecting `--configOverride`

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -13,11 +13,11 @@ interface IKeyValuePair {
   value: string;
 }
 
-async function configSetter(config: Config, argv: IKeyValuePair) {
+function configSetter(config: Config, argv: IKeyValuePair) {
   config.set(argv.key, argv.value);
 }
 
-async function configGetter(config: Config, key: string) {
+function configGetter(config: Config, key: string) {
   if (key) {
     let configObj = config.get();
     let configEntry = configObj[key];
@@ -44,10 +44,13 @@ async function configDeleter(config: Config, key: string): Promise<void> {
   }
 }
 
-function commandBuilder(cmd: (config: Config, args: any) => Promise<void>): (args: any) => void {
+function commandBuilder(cmd: (config: Config, args: any) => void | Promise<void>): (args: any) => void {
   return async (args: any) => {
     let config = new Config(args.configOverride || DEFAULT_CONFIG_PATH);
-    await cmd(config, args);
+    let promise = cmd(config, args);
+    if(promise) {
+       await promise;
+    }
     process.exit(0);
   };
 }

--- a/cli.ts
+++ b/cli.ts
@@ -39,7 +39,7 @@ async function configDeleter(config: Config, key: string): Promise<void> {
       "Are you sure you want to delete your config file?"
     );
     if (deleteConfig === true) {
-      config.delete();
+      config.clear();
     }
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { Npmrc } from "./lib/npm";
-import { Config, IConfigDictionary } from "./lib/config";
+import { Config } from "./lib/config";
 import { authenticateRegistries } from "./lib/registry-auth-reducer";
 import { AuthorizationError } from "./lib/vsts-auth-client";
 const uuid = require("uuid/v4");
@@ -38,15 +38,10 @@ export interface IRunOptions {
   stack?: boolean;
 }
 
-export async function run(options: IRunOptions = {}) {
-  let configObj: IConfigDictionary;
+export async function run(config: Config, options: IRunOptions = {}) {
+  const configObj = config.get();
 
   try {
-    if (options.configOverride) {
-      Config.setConfigPath(options.configOverride);
-    }
-
-    configObj = Config.get();
     // if npmrcPath isn't specified, default is the working directory
     options.npmrcPath = options.npmrcPath || process.cwd();
 
@@ -56,6 +51,7 @@ export async function run(options: IRunOptions = {}) {
     ]);
 
     let authenticatedRegistries = await authenticateRegistries(
+      config,
       ...projectNpmrc.getRegistries(),
       ...userNpmrc.getRegistries()
     );

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -24,28 +24,16 @@ describe("The Config module", () => {
     fs.readFileSync.mockImplementation(() => CONFIG_CONTENTS);
   });
 
-  describe("reads the config file from", () => {
-    test("the given location when overridden", () => {
-      let configOverridePath = "/foo/bar";
+  test("reads the config file from the given location", () => {
+    let configOverridePath = "/foo/bar";
 
-      fs.writeFileSync.mockImplementation((p: string) => {
-        expect(p).toEqual(configOverridePath);
-      });
-
-      Config.setConfigPath(configOverridePath);
-      Config.write({});
-      expect.assertions(1);
+    fs.writeFileSync.mockImplementation((p: string) => {
+      expect(p).toEqual(configOverridePath);
     });
 
-    test("the default location when not overridden", () => {
-      fs.writeFileSync.mockImplementation((p: string) => {
-        expect(p).toBeUndefined();
-      });
-
-      Config.setConfigPath("");
-      Config.write({});
-      expect.assertions(1);
-    });
+    let config = new Config(configOverridePath);
+    config.write({});
+    expect.assertions(1);
   });
 
   describe("reads the config", () => {
@@ -55,7 +43,7 @@ describe("The Config module", () => {
           throw { code: "ENOENT" };
         });
 
-        let config = Config.get();
+        let config = (new Config("")).get();
 
         expect(config).toEqual(ini.parse(DEFAULT_CONFIG_CONTENTS));
       });
@@ -65,7 +53,7 @@ describe("The Config module", () => {
           return "clientId=foobar\r\n";
         });
 
-        let config = Config.get();
+        let config = (new Config("")).get();
         expect(config.clientId).toEqual("foobar");
         expect(config.tokenExpiryGraceInMs).toEqual("1800000");
       });
@@ -76,8 +64,10 @@ describe("The Config module", () => {
         throw new Error("foobar");
       });
 
+      let config = new Config("");
+
       expect(() => {
-        Config.get();
+        (config).get();
       }).toThrowError("foobar");
     });
 
@@ -88,8 +78,10 @@ describe("The Config module", () => {
         throw e;
       });
 
+      let config = new Config("");
+
       expect(() => {
-        Config.get();
+        config.get();
       }).not.toThrow();
     });
   });
@@ -100,7 +92,9 @@ describe("The Config module", () => {
         expect(content).toContain("foo=bar");
       });
 
-      Config.write({ foo: "bar" });
+      let config = new Config("");
+
+      config.write({ foo: "bar" });
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
       expect.assertions(2);
     });
@@ -110,8 +104,10 @@ describe("The Config module", () => {
         throw new Error("foobar");
       });
 
+      let config = new Config("");
+
       expect(() => {
-        Config.write({ foo: "bar" });
+        config.write({ foo: "bar" });
       }).toThrowError("foobar");
     });
   });
@@ -132,17 +128,21 @@ describe("The Config module", () => {
     });
 
     test("and writes it to disk upon updating the value", () => {
-      Config.set("some", "value");
+      let config = new Config("");
+
+      config.set("some", "value");
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
       expect(configContents.indexOf("some=value") > -1).toBeTruthy();
     });
 
     test("and ensures prior updates to the config are respected", () => {
-      Config.set("key1", "val1");
+      let config = new Config("");
+
+      config.set("key1", "val1");
       expect(configContents.indexOf("key1=val1") > -1).toBeTruthy();
       expect(configContents.indexOf("key2=val2") > -1).toBeFalsy();
 
-      Config.set("key2", "val2");
+      config.set("key2", "val2");
       expect(configContents.indexOf("key1=val1") > -1).toBeTruthy();
       expect(configContents.indexOf("key2=val2") > -1).toBeTruthy();
 

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -112,6 +112,20 @@ describe("The Config module", () => {
     });
   });
 
+  describe("clears the config", () => {
+    test("on disk", () => {
+      fs.writeFileSync.mockImplementation((_path: string, content: string) => {
+        expect(content).toHaveLength(0);
+      });
+
+      let config = new Config("");
+
+      config.clear();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+      expect.assertions(2);
+    })
+  })
+
   describe("sets the config", () => {
     let configContents = "";
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -41,7 +41,11 @@ export class Config {
     writeFileSync(this.configPath, configContents);
   }
 
-  delete() {
+  /**
+   * Clear the contents of the config by writing
+   * an empty dictionary.
+   */
+  clear() {
     this.write({});
   }
 

--- a/lib/registry-auth-reducer.test.ts
+++ b/lib/registry-auth-reducer.test.ts
@@ -138,7 +138,7 @@ describe("The class Registry Auth Reducer", () => {
 
       let result: Promise<
         Array<Registry>
-      > = RegistryAuthReducer.authenticateRegistries(...registries);
+      > = RegistryAuthReducer.authenticateRegistries(null, ...registries);
 
       return expect(result)
         .resolves.toBeDefined()
@@ -182,6 +182,7 @@ describe("The class Registry Auth Reducer", () => {
 
       test("applies the lab token to all registries hosted in the same VSTS project collection", async () => {
         let result = await RegistryAuthReducer.authenticateRegistries(
+          null,
           ...sameRegistries,
           ...differentRegistries
         );
@@ -193,6 +194,7 @@ describe("The class Registry Auth Reducer", () => {
 
       test("does not authenticate the any registries which are not in the same project colleciton", async () => {
         let result = await RegistryAuthReducer.authenticateRegistries(
+          null,
           ...differentRegistries
         );
 

--- a/lib/registry-auth-reducer.ts
+++ b/lib/registry-auth-reducer.ts
@@ -4,6 +4,7 @@ import {
   getUserAuthToken
 } from "./vsts-auth-client";
 import { Registry } from "./npm";
+import { Config } from "./config";
 const k_VstfCollectionUri = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
 
 export interface IRegistryCollectionShards {
@@ -70,6 +71,7 @@ export function shardRegistriesByCollection(
 }
 
 export async function authenticateRegistries(
+  config: Config,
   ...registries: Array<Registry>
 ): Promise<Array<Registry>> {
   let registriesToAuthenticate = filterUniqueVstsRegistries(registries);
@@ -79,7 +81,7 @@ export async function authenticateRegistries(
   let labToken = getVstsLabOauthToken();
 
   if (!labToken) {
-    let userToken = await getUserAuthToken();
+    let userToken = await getUserAuthToken(config);
     registriesToAuthenticate.forEach(r => (r.token = userToken));
     return Promise.resolve(registriesToAuthenticate);
   } else {
@@ -103,10 +105,10 @@ export async function authenticateRegistries(
     if (registriesByCollection.differentCollection.length > 0) {
       console.warn(
         `Found ${
-          registriesByCollection.differentCollection.length
+        registriesByCollection.differentCollection.length
         } registries ` +
-          "which could not be authenticated:\n" +
-          registriesByCollection.differentCollection.map(x => `\t${x.url}\n`)
+        "which could not be authenticated:\n" +
+        registriesByCollection.differentCollection.map(x => `\t${x.url}\n`)
       );
     }
 

--- a/lib/vsts-auth-client.test.ts
+++ b/lib/vsts-auth-client.test.ts
@@ -5,7 +5,8 @@ jest.mock("./config");
 import {
   AuthorizationError,
   getUserAuthToken,
-  setRefreshToken
+  setRefreshToken,
+  getVstsLabOauthToken
 } from "./vsts-auth-client";
 import * as querystring from 'querystring';
 
@@ -54,6 +55,14 @@ describe("In the vsts-auth-client module", () => {
       expect(mockConfig.set).toHaveBeenCalledTimes(1);
       expect(mockConfig.set).toHaveBeenCalledWith("refresh_token", fakeToken);
     });
+  });
+  describe("the getVstsLabOauthToken static method", () => {
+    test("checks the environment variable $SYSTEM_ACCESSTOKEN", () => {
+      let fakeValue = "test_systemaccesstoken";
+      process.env["SYSTEM_ACCESSTOKEN"] = fakeValue;
+
+      expect(getVstsLabOauthToken()).toEqual(fakeValue);
+    })
   });
 
   describe("the getUserAuthToken static  method", () => {

--- a/lib/vsts-auth-client.test.ts
+++ b/lib/vsts-auth-client.test.ts
@@ -9,7 +9,6 @@ import {
 } from "./vsts-auth-client";
 import * as querystring from 'querystring';
 
-import { Config as config } from "./config";
 let fetch = require("node-fetch");
 let jwt = require("jsonwebtoken");
 
@@ -48,25 +47,24 @@ describe("In the vsts-auth-client module", () => {
   });
   describe("the setRefreshToken static method", () => {
     test("should set the config entry for refresh_token with the given token", () => {
+      const mockConfig = getMockConfig();
       const fakeToken = "foo";
-      setRefreshToken(fakeToken);
+      setRefreshToken(mockConfig, fakeToken);
 
-      expect(config.set).toHaveBeenCalledTimes(1);
-      expect(config.set).toHaveBeenCalledWith("refresh_token", fakeToken);
+      expect(mockConfig.set).toHaveBeenCalledTimes(1);
+      expect(mockConfig.set).toHaveBeenCalledWith("refresh_token", fakeToken);
     });
   });
+
   describe("the getUserAuthToken static  method", () => {
     const fakeCode = "foo";
     const fakeAccessToken = "baz";
     const nowInMs = 10000;
     const now = nowInMs / 1000;
 
-    beforeEach(() => {
-      (config.get as jest.Mock).mockImplementation(() => ({
-        tokenEndpoint: "foo",
-        refresh_token: "foo"
-      }));
 
+
+    beforeEach(() => {
       fetch.mockImplementation((url: string) => {
         const queryString = querystring.stringify({ code: fakeCode });
 
@@ -81,20 +79,20 @@ describe("In the vsts-auth-client module", () => {
     });
 
     test("should reject if the config does not have a tokenEndpoint", () => {
-      (config.get as jest.Mock).mockImplementation(() => ({}));
+      let mockConfig = getMockConfig({});
 
-      return expect(getUserAuthToken()).rejects.toHaveProperty(
+      return expect(getUserAuthToken(mockConfig)).rejects.toHaveProperty(
         "message",
         "invalid config, missing tokenEndpoint"
       );
     });
 
     test("should reject if the config does not have a refresh_token", () => {
-      (config.get as jest.Mock).mockImplementation(() => ({
+      let mockConfig = getMockConfig({
         tokenEndpoint: "foo"
-      }));
+      });
 
-      let result = getUserAuthToken();
+      let result = getUserAuthToken(mockConfig);
 
       return expect(result)
         .rejects.toBeInstanceOf(AuthorizationError)
@@ -108,13 +106,15 @@ describe("In the vsts-auth-client module", () => {
 
     describe("should reject if the token endpoint returns", () => {
       test("an error", () => {
+        let mockConfig = getMockConfig();
+
         const errorObj = { error: "foo" };
 
         fetch.mockImplementation(() => {
           return Promise.reject(errorObj);
         });
 
-        return expect(getUserAuthToken()).rejects.toEqual(errorObj);
+        return expect(getUserAuthToken(mockConfig)).rejects.toEqual(errorObj);
       });
 
       describe("a response without", () => {
@@ -129,6 +129,7 @@ describe("In the vsts-auth-client module", () => {
 
         testData.forEach(t => {
           test(t.name, () => {
+            let mockConfig = getMockConfig();
             fetch.mockImplementation(() => {
               return Promise.resolve({
                 json: () => {
@@ -137,7 +138,7 @@ describe("In the vsts-auth-client module", () => {
               });
             });
 
-            return expect(getUserAuthToken()).rejects.toContain(
+            return expect(getUserAuthToken(mockConfig)).rejects.toContain(
               "malformed response body:\n"
             );
           });
@@ -146,11 +147,13 @@ describe("In the vsts-auth-client module", () => {
     });
 
     test("should make requests with refresh_token supplied as the code and return the access_token", () => {
+      let mockConfig = getMockConfig();
+
       jwt.decode.mockImplementation(() => ({ nbf: now }));
       jest.spyOn(Date, "now").mockImplementation(() => nowInMs);
       jest.advanceTimersByTime(1000);
 
-      return expect(getUserAuthToken())
+      return expect(getUserAuthToken(mockConfig))
         .resolves.toEqual(fakeAccessToken)
         .then(() => {
           expect(fetch).toHaveBeenCalledTimes(1);
@@ -159,6 +162,7 @@ describe("In the vsts-auth-client module", () => {
     });
 
     test("should not resolve until after the nbf claim in the returned token is >= the current time", async () => {
+      let mockConfig = getMockConfig();
       const delay = 60000; // 1 minute
       jest.spyOn(Date, "now").mockImplementation(() => nowInMs);
       jwt.decode.mockImplementation(() => ({
@@ -170,7 +174,7 @@ describe("In the vsts-auth-client module", () => {
         f();
       });
 
-      let authResponse = await getUserAuthToken();
+      let authResponse = await getUserAuthToken(mockConfig);
 
       expect(authResponse).toEqual(fakeAccessToken);
       expect(fetch).toHaveBeenCalledTimes(1);
@@ -178,3 +182,14 @@ describe("In the vsts-auth-client module", () => {
     });
   });
 });
+
+
+function getMockConfig(mockConfigObj: any = {
+  tokenEndpoint: "foo",
+  refresh_token: "foo"
+}): any {
+  return {
+    set: jest.fn(),
+    get: jest.fn().mockReturnValue(mockConfigObj)
+  }
+}

--- a/lib/vsts-auth-client.ts
+++ b/lib/vsts-auth-client.ts
@@ -26,12 +26,12 @@ export function isVstsFeedUrl(url: string): boolean {
   return url.indexOf("pkgs.visualstudio.com/_packaging") > -1;
 }
 
-export function setRefreshToken(token: string) {
-  Config.set(k_REFRESH_TOKEN, token);
+export function setRefreshToken(config: Config, token: string) {
+  config.set(k_REFRESH_TOKEN, token);
 }
 
-export async function getUserAuthToken(): Promise<string> {
-  let configObj = Config.get();
+export async function getUserAuthToken(config: Config): Promise<string> {
+  let configObj = config.get();
   // validate config
   if (!configObj || !configObj.tokenEndpoint) {
     return Promise.reject(new Error("invalid config, missing tokenEndpoint"));
@@ -50,7 +50,7 @@ export async function getUserAuthToken(): Promise<string> {
   }
 
   // stash the refresh_token
-  Config.set(k_REFRESH_TOKEN, body[k_REFRESH_TOKEN]);
+  config.set(k_REFRESH_TOKEN, body[k_REFRESH_TOKEN]);
   const accessToken = body.access_token;
 
   // VSTS auth service doesn't accomodate clock skew well

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "better-vsts-npm-auth",
-  "version": "4.1.6",
+  "name": "internal-better-vsts-npm-auth",
+  "version": "4.1.9",
   "description":
     "Platform agnostic library which provides a robust solution for maintaining credentials in your npmrc files",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "internal-better-vsts-npm-auth",
-  "version": "4.1.9",
+  "name": "better-vsts-npm-auth",
+  "version": "4.1.7",
   "description":
     "Platform agnostic library which provides a robust solution for maintaining credentials in your npmrc files",
   "main": "dist/index.js",


### PR DESCRIPTION
This turned into a bigger thing than I set out to do. I tried fixing the issue here, as well as in my team's dev tooling, which we'll ultimately use to wrap this -- but reasoning about the global Config was very confusing. I ended up turning it into an instanced class along the way, and limiting it to a single instantiation in `cli.ts`. This will also make it easier for us when we consume this, as we can keep our instance of Config and be assured that a given function is using the right Config.

If this is overboard, please LMK what you'd prefer and I'll gladly try to reduce the scope of this change! This just makes the API feel nicer to me :)