### PR TITLE
Adds Yarn v2 Support

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -73,6 +73,11 @@ const argv = require("yargs")
     describe: "path to npmrc config",
     type: "string"
   })
+  .options("y", {
+    alias: "yarnrcYmlPath",
+    describe: "path to yarnrc.yml config",
+    type: "string"
+  })
   .options("c", {
     alias: "configOverride",
     describe: "alternate path to this tool's configuration file",

--- a/lib/registry-auth-reducer.test.ts
+++ b/lib/registry-auth-reducer.test.ts
@@ -2,6 +2,7 @@ let vstsAuthClient = require("./vsts-auth-client");
 
 import * as RegistryAuthReducer from "./registry-auth-reducer";
 import { Registry } from "./npm";
+import { YarnRcYmlRegistry } from "./yarnrcyml";
 
 const k_getVstsLabOauthToken = "getVstsLabOauthToken";
 
@@ -162,7 +163,7 @@ function generateTests(name: string, useLegacyUri: boolean) {
           .mockReturnValue(Promise.resolve(token));
 
         let result: Promise<Array<
-          Registry
+          Registry | YarnRcYmlRegistry
         >> = RegistryAuthReducer.authenticateRegistries(...registries);
 
         return expect(result)

--- a/lib/registry-auth-reducer.ts
+++ b/lib/registry-auth-reducer.ts
@@ -4,19 +4,20 @@ import {
   getUserAuthToken,
 } from "./vsts-auth-client";
 import { Registry } from "./npm";
+import { YarnRcYmlRegistry } from "./yarnrcyml";
 const k_VstfCollectionUri = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
 
 export interface IRegistryCollectionShards {
-  sameCollection: Array<Registry>;
-  differentCollection: Array<Registry>;
+  sameCollection: Array<Registry | YarnRcYmlRegistry>;
+  differentCollection: Array<Registry | YarnRcYmlRegistry>;
 }
 /**
  * Given an array of Registry objects, returns only those
  * which are unique and correspond to a VSTS feed.
  */
 export function filterUniqueVstsRegistries(
-  registries: Array<Registry>
-): Array<Registry> {
+  registries: Array<Registry | YarnRcYmlRegistry>
+): Array<Registry | YarnRcYmlRegistry> {
   return registries.filter((e, i) => {
     try {
       let _isUnique = registries.findIndex((v) => v.url === e.url) === i;
@@ -29,7 +30,7 @@ export function filterUniqueVstsRegistries(
   });
 }
 
-export function isInSameCollection(r: Registry): boolean {
+export function isInSameCollection(r: Registry | YarnRcYmlRegistry): boolean {
   if (process.env[k_VstfCollectionUri]) {
     let currentCollectionUri = process.env[k_VstfCollectionUri] as string;
     let isLegacyVstsUri =
@@ -57,7 +58,7 @@ export function isInSameCollection(r: Registry): boolean {
  * as it depends on SYSTEM_TEAMFOUNDATIONCOLLECTIONURI.
  */
 export function shardRegistriesByCollection(
-  registries: Array<Registry>
+  registries: Array<Registry | YarnRcYmlRegistry>
 ): IRegistryCollectionShards {
   let result: IRegistryCollectionShards = {
     sameCollection: [],
@@ -77,8 +78,8 @@ export function shardRegistriesByCollection(
 }
 
 export async function authenticateRegistries(
-  ...registries: Array<Registry>
-): Promise<Array<Registry>> {
+  ...registries: Array<Registry | YarnRcYmlRegistry>
+): Promise<Array<Registry | YarnRcYmlRegistry>> {
   let registriesToAuthenticate = filterUniqueVstsRegistries(registries);
 
   // if we can get an OAuth token for the user, that is

--- a/lib/yarnrcyml.test.ts
+++ b/lib/yarnrcyml.test.ts
@@ -8,13 +8,13 @@ let { execSync } = require("child_process");
 
 import { IYarnRcYmlSettings, YarnrcYml, YarnRcYmlRegistry } from "./yarnrcyml";
 
-describe("In the YarnRmYml module,", () => {
+describe("In the YarnRcYml module,", () => {
   afterEach(() => {
     jest.resetAllMocks();
     expect.hasAssertions();
   });
 
-  describe("the YarnRmYml class", () => {
+  describe("the YarnRcYml class", () => {
     /**
      * @type {YarnrcYml}
      */
@@ -90,7 +90,7 @@ describe("In the YarnRmYml module,", () => {
       });
 
       test("resolves settings as JSON from .yarnrc.yml file with entries", () => {
-        const registryName = "//domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/";
+        const registryName = "//foo.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/";
         const token = "foobar";
         fs.readFile.mockImplementation((_a: any, _b: any, cb: Function) => {
           cb(null, `npmRegistries:\n  "${registryName}":\n    npmAlwaysAuth: true\n    npmAuthToken: ${token}\n`);
@@ -100,7 +100,7 @@ describe("In the YarnRmYml module,", () => {
           "settings",
           { 
             npmRegistries: {
-              ["//domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/"]: {
+              ["//foo.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/"]: {
                 npmAlwaysAuth: true,
                 npmAuthToken: "foobar"
               }

--- a/lib/yarnrcyml.test.ts
+++ b/lib/yarnrcyml.test.ts
@@ -1,0 +1,276 @@
+jest.mock("fs");
+jest.mock("path");
+jest.mock("child_process");
+
+let path = require("path");
+let fs = require("fs");
+let { execSync } = require("child_process");
+
+import { IYarnRcYmlSettings, YarnrcYml, YarnRcYmlRegistry } from "./yarnrcyml";
+
+describe("In the YarnRmYml module,", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    expect.hasAssertions();
+  });
+
+  describe("the YarnRmYml class", () => {
+    /**
+     * @type {YarnrcYml}
+     */
+    let foo: YarnrcYml;
+    beforeEach(() => (foo = new YarnrcYml("foo")));
+
+    describe("has a constructor which", () => {
+      test("constructs a filePath to a .yarnrc.yml file when given a directory", () => {
+        path.join.mockImplementation((a: string, b: string) => a + "/" + b);
+        let foo = new YarnrcYml("/some/path");
+        expect(foo.filePath).toEqual("/some/path/.yarnrc.yml");
+      });
+
+      test("uses the filePath as given when it points to a .yarnrc.yml file", () => {
+        const weirdPath = "/some/path/with/.an-oddly_namedButValid.yarnrc.yml";
+        let foo = new YarnrcYml(weirdPath);
+        expect(foo.filePath).toEqual(weirdPath);
+      });
+
+      test("initialized an empty settings object", () => {
+        let foo = new YarnrcYml("somepath");
+        expect(foo.settings).toEqual({});
+      });
+    });
+
+    describe("has a method getRegistries which", () => {
+      test("returns an empty array when there are no settings", () => {
+        expect(foo.getRegistries()).toEqual([]);
+      });
+
+      test("returns an empty array when none of the settings are registreies", () => {
+        foo.settings = {
+          "always-auth": "true",
+          cache: "some/path"
+        };
+
+        expect(foo.getRegistries()).toEqual([]);
+      });
+
+      test("returns an array of Registry objects when settings contains one or more registries", () => {
+        const myregistry = "https://myregistry.com";
+        const myprivateregistry = "https://private.myregistry.com";
+
+        foo.settings = {
+          "always-auth": "false",
+          npmRegistryServer: myregistry,
+          npmScopes: {
+            private: {
+              npmRegistryServer: myprivateregistry,
+            }
+          }
+        };
+
+        let registries = foo.getRegistries();
+
+        expect(registries).not.toEqual([]);
+        expect(registries).toHaveLength(2);
+        expect(registries[0].url).toEqual(myregistry);
+        expect(registries[1].url).toEqual(myprivateregistry);
+      });
+    });
+
+    describe("has a method readSettingsFromFile which", () => {
+      test("rejects when there is an error reading the .yarnrc.yml file", () => {
+        fs.readFile.mockImplementation((_a: any, _b: any, cb: Function) => {
+          cb({ code: "ERROR" });
+        });
+
+        return expect(foo.readSettingsFromFile()).rejects.toHaveProperty(
+          "code",
+          "ERROR"
+        );
+      });
+
+      test("resolves settings as JSON from .yarnrc.yml file with entries", () => {
+        const registryName = "//domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/";
+        const token = "foobar";
+        fs.readFile.mockImplementation((_a: any, _b: any, cb: Function) => {
+          cb(null, `npmRegistries:\n  "${registryName}":\n    npmAlwaysAuth: true\n    npmAuthToken: ${token}\n`);
+        });
+
+        return expect(foo.readSettingsFromFile()).resolves.toHaveProperty(
+          "settings",
+          { 
+            npmRegistries: {
+              ["//domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/"]: {
+                npmAlwaysAuth: true,
+                npmAuthToken: "foobar"
+              }
+            } 
+          }
+        );
+      });
+
+      describe("resolves settings as empty JSON when .yarnrc.yml", () => {
+        test("is empty", () => {
+          fs.readFile.mockImplementation((_a: any, _b: any, cb: Function) => {
+            cb(null, "");
+          });
+
+          return expect(foo.readSettingsFromFile()).resolves.toHaveProperty(
+            "settings",
+            {}
+          );
+        });
+
+        test("is whitespace", () => {
+          fs.readFile.mockImplementation((_a: any, _b: any, cb: Function) => {
+            cb(null, "\r\n\t  ");
+          });
+
+          return expect(foo.readSettingsFromFile()).resolves.toHaveProperty(
+            "settings",
+            {}
+          );
+        });
+
+        test("does not exist", () => {
+          fs.readFile.mockImplementation((_a: any, _b: any, cb: Function) => {
+            cb({ code: "ENOENT" });
+          });
+
+          let result = foo.readSettingsFromFile();
+
+          return expect(result)
+            .resolves.toBeInstanceOf(YarnrcYml)
+            .then(() => expect(result).resolves.toHaveProperty("settings", {}));
+        });
+      });
+    });
+
+    describe("has a method saveSettingsToFile which", () => {
+      test("rejects if there is an error writing the file", () => {
+        const someError = { error: "foo" };
+        fs.writeFile.mockImplementation(
+          (_path: string, _content: string, cb: Function) => {
+            cb(someError);
+          }
+        );
+
+        return expect(foo.saveSettingsToFile()).rejects.toEqual(someError);
+      });
+
+      test("writes the js-yaml-encoded settings", () => {
+        foo.settings = { some: "value" };
+        fs.writeFile.mockImplementation(
+          (_path: string, content: string, cb: Function) => {
+            expect(content).toContain("some: value");
+            cb(null);
+          }
+        );
+        return expect(foo.saveSettingsToFile())
+          .resolves.toBeUndefined()
+          .then(() => {
+            expect.assertions(2);
+          });
+      });
+    });
+
+    describe("has a method getUserNpmrc which", () => {
+      test("returns an YarnrcYml object corresponding to the 'userconfig'", () => {
+        execSync.mockImplementation(() => "/foobar/.npmrc\r\n");
+        path.join.mockImplementation((a: string, b: string) => {
+          return a.endsWith("/") ? a + b : a + "/" + b;
+        });
+        let result = YarnrcYml.getUserNpmrc();
+
+        expect(result).toBeInstanceOf(YarnrcYml);
+        expect(result).toHaveProperty("filePath", "/foobar/.yarnrc.yml");
+      });
+
+      test("returns the userconfig path with .yarnrc.yml at the end, if the path doesn't end with .npmrc", () => {
+        execSync.mockImplementation(() => "/foobar/\r\n");
+        path.join.mockImplementation((a: string, b: string) => {
+          return a.endsWith("/") ? a + b : a + "/" + b;
+        });
+        let result = YarnrcYml.getUserNpmrc();
+
+        expect(result).toBeInstanceOf(YarnrcYml);
+        expect(result).toHaveProperty("filePath", "/foobar/.yarnrc.yml");
+      });
+    });
+  });
+});
+
+function generateRegistryTests(name: string, useLegacyUrl: boolean) {
+
+  describe(name, () => {
+    describe("has a constructor which", () => {
+      describe("constructs an object", () => {
+        let feed = "npm-mirror";
+        let project = "foobar";
+        let fakeRegistry = useLegacyUrl ? `https://${project}.pkgs.visualstudio.com/_packaging/${feed}/npm/registry/` : `https://pkgs.dev.azure.com/${project}/_packaging/${feed}/npm/registry`;
+        let o: YarnRcYmlRegistry;
+        beforeAll(() => {
+          o = new YarnRcYmlRegistry(fakeRegistry);
+        });
+
+        test("has a public property 'url'", () => {
+          expect(o).toHaveProperty("url", fakeRegistry);
+        });
+
+        test("has a public property 'token' which is empty by default", () => {
+          expect(o).toHaveProperty("token", "");
+        });
+
+        test("has a public property 'feed' which is the name of the VSTS feed", () => {
+          expect(o).toHaveProperty("feed", feed);
+        });
+
+        test("has a public property 'project' which is the name of the VSTS project collection", () => {
+          expect(o).toHaveProperty("project", project);
+        });
+      });
+    });
+
+    describe("has a method 'getAuthSettings' which", () => {
+      // TODO - test for basic auth settings and token vs. basic auth precedence
+
+      /**
+       * @type {YarnRcYmlRegistry}
+       */
+      let o: YarnRcYmlRegistry;
+      beforeEach(() => {
+        o = new YarnRcYmlRegistry(useLegacyUrl ?
+          "https://foobar.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/" : "https://pkgs.dev.azure.com/foobar/_packaging/npm-mirror/npm/registry/"
+        );
+      });
+      afterEach(() => (o = undefined));
+      test("returns an empty object if the Registry does not have a token and does not have basicAuthSettings", () => {
+        expect(o.getAuthSettings()).toEqual({});
+      });
+      test("returns an object with npmAuthIdent set to the username and password if both are populated and there is no token", () => {
+        o.basicAuthSettings = {
+          username: "foo",
+          password: "bar"
+        };
+
+        let result = o.getAuthSettings();
+        expect(result.npmAuthIdent).toEqual("foo:bar");
+      })
+      test("returns a npmRegistries object, containing a key with the 'registry/' suffix", () => {
+        const fakeToken = "foo";
+        o.token = fakeToken;
+
+        let result = o.getAuthSettings();
+        const k_withRegistrySuffix: string = useLegacyUrl ?
+          "//foobar.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/" : "//pkgs.dev.azure.com/foobar/_packaging/npm-mirror/npm/registry/";
+
+        const npmRegistries = result.npmRegistries as IYarnRcYmlSettings;
+        expect(Object.getOwnPropertyNames(result)).toHaveLength(1);
+        expect((npmRegistries[k_withRegistrySuffix] as IYarnRcYmlSettings).npmAuthToken).toEqual(fakeToken);
+      });
+    });
+  });
+}
+
+generateRegistryTests("(legacy) the YarnRcYmlRegistry class", true);
+generateRegistryTests("the YarnRcYmlRegistry class", false);

--- a/lib/yarnrcyml.ts
+++ b/lib/yarnrcyml.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import { execSync } from "child_process";
 import * as fs from "fs";
-import * as yaml from 'yaml';
+import * as yaml from "js-yaml";
 
 export type IYarnRcYmlSettings = {
   [key: string]: IYarnRcYmlSettings | string;
@@ -87,7 +87,7 @@ export type IYarnRcYmlSettings = {
         } else {
           try {
             console.log("config from", that.filePath);
-            that.settings = yaml.parse(data || "");
+            that.settings = yaml.load(data || "") as IYarnRcYmlSettings;
 
             if (that.settings[""]) {
               delete that.settings[""];
@@ -109,7 +109,7 @@ export type IYarnRcYmlSettings = {
    */
    async saveSettingsToFile() {
     return new Promise<void>((resolve, reject) => {
-      fs.writeFile(this.filePath, yaml.stringify(this.settings), err => {
+      fs.writeFile(this.filePath, yaml.dump(this.settings), err => {
         if (err) {
           reject(err);
         } else {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jsonwebtoken": "^8.1.0",
     "node-fetch": "^2.3.0",
     "uuid": "^3.1.0",
+    "yaml": "^1.10.2",
     "yargs": "^10.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,15 +30,16 @@
   "dependencies": {
     "ini": "^1.3.4",
     "input": "^1.0.1",
+    "js-yaml": "^4.1.0",
     "jsonwebtoken": "^8.1.0",
     "node-fetch": "^2.3.0",
     "uuid": "^3.1.0",
-    "yaml": "^1.10.2",
     "yargs": "^10.0.3"
   },
   "devDependencies": {
     "@types/ini": "^1.3.29",
     "@types/jest": "^22.1.4",
+    "@types/js-yaml": "^4.0.1",
     "@types/jsonwebtoken": "^7.2.5",
     "@types/node": "^9.4.6",
     "@types/node-fetch": "^2.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,11 +73,6 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 acorn-globals@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
@@ -175,19 +170,6 @@ append-transform@^0.4.0:
   integrity sha1-126/jKlNJ24keja61EpLdKthGZE=
   dependencies:
     default-require-extensions "^1.0.0"
-
-aproba@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
-  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -653,11 +635,6 @@ chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chownr@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
-  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
-
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
@@ -758,11 +735,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.7.0"
@@ -873,7 +845,7 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -894,11 +866,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -946,22 +913,12 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -1373,13 +1330,6 @@ fs-extra@6.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1397,20 +1347,6 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -1542,11 +1478,6 @@ has-symbols@^1.0.0, has-symbols@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
-
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -1614,19 +1545,12 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -1666,7 +1590,7 @@ inherits@2, inherits@^2.0.1, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -2878,21 +2802,6 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -2901,7 +2810,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -2950,15 +2859,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -2990,30 +2890,6 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
-
 normalize-package-data@^2.3.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -3030,27 +2906,6 @@ normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
-
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
 
 npm-path@^2.0.2:
   version "2.0.4"
@@ -3074,16 +2929,6 @@ npm-which@^3.0.1:
     commander "^2.9.0"
     npm-path "^2.0.2"
     which "^1.2.10"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -3221,18 +3066,10 @@ os-locale@^3.1.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-osenv@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -3471,16 +3308,6 @@ randomatic@^3.0.0:
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -3498,7 +3325,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6:
+readable-stream@^2.0.1, readable-stream@^2.0.2:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -3756,7 +3583,7 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -3979,7 +3806,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -4068,11 +3895,6 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 subarg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
@@ -4113,19 +3935,6 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 test-exclude@^4.2.1:
   version "4.2.3"
@@ -4429,13 +4238,6 @@ which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
-
 word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -4490,10 +4292,10 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^8.1.0:
   version "8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
   integrity sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==
 
+"@types/js-yaml@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.1.tgz#5544730b65a480b18ace6b6ce914e519cec2d43b"
+  integrity sha512-xdOvNmXmrZqqPy3kuCQ+fz6wA0xU5pji9cd1nDrflWaAWtYLLGk5ykW0H6yg5TVyehHP1pfmuuSaZkhP+kspVA==
+
 "@types/jsonwebtoken@^7.2.5":
   version "7.2.8"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz#8d199dab4ddb5bba3234f8311b804d2027af2b3a"
@@ -177,6 +182,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -2307,6 +2317,13 @@ js-yaml@^3.13.1, js-yaml@^3.7.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -4291,11 +4308,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yaml@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Adds Yarn v2 Support to better-vsts-npm-auth.

Implements yarn v2 support by adding a check in `index.ts` which detects the presence of a .yarnrc.yml file. If that is detected then the new `YarnrcYml` class is used instead of `Npmrc`.

Fixes #38